### PR TITLE
small fixes for: env var behavior, table creation on startup

### DIFF
--- a/server/satgpt.py
+++ b/server/satgpt.py
@@ -2,8 +2,9 @@ import traceback
 import openai
 from flask import Flask, Response, request, jsonify
 from flask_cors import CORS
-from dotenv import load_dotenv
 import os
+from dotenv import load_dotenv
+load_dotenv(verbose=True, dotenv_path=".env", override=True)
 from ln import add_invoice, lookup_invoice
 from db.db import (
     check_invoice_used,
@@ -14,8 +15,7 @@ from db.db import (
 )
 from util import price, base64_to_hex
 
-# Load env vars
-load_dotenv(verbose=True, dotenv_path=".env", override=True)
+
 # Set up the OpenAI API credentials
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
@@ -153,5 +153,7 @@ def query_chatbot():
 
 # Start the Flask app on localhost:5000
 if __name__ == "__main__":
-    app.run(debug=True)
-    create_invoices_table()
+    try: 
+        create_invoices_table()
+    finally:
+        app.run(debug=True)


### PR DESCRIPTION
Addresses two bugs: 
 - 1.) env vars not loading in `ln` and `db` modules,
 -  2.) `create_invoice_table()` not executed on app startup

1.) moving `load_dotenv()` above the imports from `ln` and `db` allows the call to os.getenv in these modules to reference whatever value are in your `.env` file. 

The tricky thing is activating you pipenv environment (`>pipenv shell`) will already populate the .env variables into your environment variables. But if you don't make this changes to the .env file after activating, they won't be read by the program as it stood. This change looks ugly, but `load_dotenv` doesn't do anything right now unless you do it this way.

2.) `app.run()` was blocking `create_invoice_table()` from creating the table on startup. Reversed the order so they both can run.